### PR TITLE
Add support for Django 1.11 and 2.x

### DIFF
--- a/better_filter_widget/widgets.py
+++ b/better_filter_widget/widgets.py
@@ -2,6 +2,7 @@ from django.utils.safestring import mark_safe
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django import forms
 
+
 class BetterFilterWidget(forms.SelectMultiple):
     class Media:
         extend = False
@@ -10,8 +11,8 @@ class BetterFilterWidget(forms.SelectMultiple):
         }
         js = ('js/better-filter-widget.js', )
 
-    def render(self, name, value, attrs=None, choices=()):
-        output = super(BetterFilterWidget, self).render(name, value, attrs, choices)
+    def render(self, name, value, attrs=None, renderer=None):
+        output = super(BetterFilterWidget, self).render(name, value, attrs, renderer)
         output += u'''
         	<script type="text/javascript">
 				(function($) {


### PR DESCRIPTION
Updated the render choices parameter to renderer as per the base class "Widget", otherwise "**AttributeError**: 'tuple' object has no attribute 'render'" is raised.

In the [Django documentation](https://docs.djangoproject.com/en/1.11/ref/forms/widgets/#django.forms.Widget.render) is stated that support for subclasses that don’t accept the renderer parameter will be removed in Django 2.1.